### PR TITLE
Update kuadro package to 0.9.5 and fix uninstall script

### DIFF
--- a/kuadro/kuadro.nuspec
+++ b/kuadro/kuadro.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>kuadro</id>
     <title>Kuadro</title>
-    <version>0.8.5</version>
+    <version>0.9.5</version>
 	<packageSourceUrl>https://github.com/TakataSanshiro/Chocolatey-Packages/tree/master/kuadro</packageSourceUrl>
     <authors>Kruel Games</authors>
     <owners>Sanshiro</owners>

--- a/kuadro/tools/chocolateyinstall.ps1
+++ b/kuadro/tools/chocolateyinstall.ps1
@@ -1,18 +1,17 @@
 ﻿$ErrorActionPreference = 'Stop';
 
 $packageName = 'kuadro'
-$url = 'http://kruelgames.com/tools/kuadro/latest' 
-$checksum = 'BEDD9F480D7DF47F1D6E14F37726A7DA105CC3641FB38B063138E91856594E6C'
+$url = 'http://kruelgames.com/static/kuadro-0.9.5.exe'
+$checksum = 'B54DBEF113D83A25973EAAA3EEB8B34A4AEAF4EE638444EAF05D0A212863AC29'
 $checksumType = 'sha256'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 Get-ChocolateyWebFile -PackageName "$packageName" `
-                      -FileFullPath "$toolsDir\kuadro-0.8.5.exe" `
+                      -FileFullPath "$toolsDir\kuadro-0.9.5.exe" `
                       -Url "$url" `
                       -Checksum "$checksum" `
                       -ChecksumType "$checksumType"
 
 # Create an exe shotcut at the desktop.
 Install-ChocolateyShortcut   -ShortcutFilePath "$Home\Desktop\kuadro.lnk" `
-						     -TargetPath "$toolsDir\kuadro-0.8.5.exe"
-							 
+						     -TargetPath "$toolsDir\kuadro-0.9.5.exe"

--- a/kuadro/tools/chocolateyuninstall.ps1
+++ b/kuadro/tools/chocolateyuninstall.ps1
@@ -1,7 +1,3 @@
 ﻿$ErrorActionPreference = 'Stop';
 
-Uninstall-ChocolateyZipPackage `
-  -PackageName "kuadro" `
-  -ZipFileName "kuadro*" 
-
 Remove-item -path "$Home\Desktop\kuadro.lnk" -Force -ErrorAction 'SilentlyContinue'


### PR DESCRIPTION
As seen in http://kruelgames.com/tools/kuadro/, the latest kuadro version is now 0.9.5.

The URL was adapted to point directly to the versionned download link. The uninstall script was also modified because it was not working anymore.

This was tested locally with success on chocolatey 0.10.11