### PR TITLE
Update firealpaca to v2.1.13

### DIFF
--- a/firealpaca/firealpaca.nuspec
+++ b/firealpaca/firealpaca.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>firealpaca</id>
     <title>FireAlpaca</title>
-    <version>2.1.10</version>
+    <version>2.1.13</version>
     <packageSourceUrl>https://github.com/TakataSanshiro/Chocolatey-Packages/tree/master/firealpaca</packageSourceUrl>
     <authors>firealpaca.com</authors>
     <owners>Sanshiro</owners>

--- a/firealpaca/tools/chocolateyinstall.ps1
+++ b/firealpaca/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@
 $packageName    = 'firealpaca'
 $installerType  = 'exe'
 $url            = 'https://firealpaca.com/download/win64'
-$checksum       = 'A266A7C62C58053225755009717D6BF86DFD5CEDBA4760E079E5F64E1F418DDD'
+$checksum       = 'E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855'
 $toolsDir       = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
 $silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 $validExitCodes = @(0)


### PR DESCRIPTION
Hello! The current install script fire firealpaca is failing as the checksum is for version 2.1.10. This is my first time opening a pull request, so please forgive any mistakes.