### PR TITLE
Update dnSpy to 6.0.4

### DIFF
--- a/dnspy/dnspy.nuspec
+++ b/dnspy/dnspy.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>dnspy</id>
     <title>dnSpy</title>
-    <version>6.0.3</version>
+    <version>6.0.4</version>
     <packageSourceUrl>https://github.com/TakataSanshiro/Chocolatey-Packages/tree/master/dnspy</packageSourceUrl>
     <authors>0xd4d</authors>
     <owners>Sanshiro</owners>

--- a/dnspy/tools/chocolateyinstall.ps1
+++ b/dnspy/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop';
 
 $packageName = 'dnspy'
-$url = 'https://github.com/0xd4d/dnSpy/releases/download/v6.0.3/dnSpy-net472.zip' 
-$checksum = 'BE368CE75245BFAFDA75335DC18AA82F763CFB3137B40A039ECAD375575E20B6'
+$url = 'https://github.com/0xd4d/dnSpy/releases/download/v6.0.4/dnSpy-net472.zip' 
+$checksum = '68C0334F921F542B29CC9DB670018C46A34E1E9AA81F996C51A3A9EA656479F1'
 $checksumType = 'sha256'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
  


### PR DESCRIPTION
Link to 6.0.3 is broken.

dnSpy was updated to 6.0.4: https://github.com/0xd4d/dnSpy/releases/