### PR TITLE
Github Desktop move to internal

### DIFF
--- a/automatic/github-desktop/tools/LICENSE.txt
+++ b/automatic/github-desktop/tools/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/automatic/github-desktop/tools/VERIFICATION.txt
+++ b/automatic/github-desktop/tools/VERIFICATION.txt
@@ -1,0 +1,10 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+ 
+1. Download release from 
+    32-Bit: <https://desktop.githubusercontent.com/releases/2.5.6-e0dac138/GitHubDesktopSetup.exe>
+
+2. Get sha256 checksum with utility of choice
+
+3. Check that it matches checksum of included installer

--- a/automatic/github-desktop/tools/chocolateyinstall.ps1
+++ b/automatic/github-desktop/tools/chocolateyinstall.ps1
@@ -1,13 +1,16 @@
 ﻿$ErrorActionPreference = 'Stop';
+$toolsDir              = Split-Path -parent $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
   packageName    = 'github-desktop'
   installerType  = 'exe'
-  url            = 'https://desktop.githubusercontent.com/releases/2.5.6-e0dac138/GitHubDesktopSetup.exe'
-  checksum       = '922152e9f8b607aac0a989dacf5151ebde7b06e9e1d542362d6221afc87db1ae'
+  file           = (Get-Childitem -Path $toolsDir -Filter "*.exe").fullname
   checksumType   = 'sha256'
   silentArgs     = '/S /nolaunch'
   validExitCodes = @(0)
   softwareName   = 'GitHub Desktop'
 }
-Install-ChocolateyPackage @packageArgs
+
+Install-ChocolateyInstallPackage @packageArgs
+
+Remove-Item "$toolsDir\*.exe" -Force -EA SilentlyContinue | Out-Null

--- a/automatic/github-desktop/update.ps1
+++ b/automatic/github-desktop/update.ps1
@@ -3,14 +3,13 @@ import-module au
 $releases = 'https://central.github.com/deployments/desktop/desktop/latest/win32'
 
 function global:au_BeforeUpdate {
-  $Latest.Checksum32 = Get-RemoteChecksum -Url $Latest.Url32 -Algorithm 'SHA256'
+  Get-RemoteFiles -Purge -NoSuffix 
 }
 
 function global:au_SearchReplace {
   @{
-    ".\tools\chocolateyInstall.ps1" = @{
-        "(?i)(^\s*url\s*=\s*)('.*')"        = "`$1'$($Latest.URL32)'"
-        "(?i)(^\s*checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
+    ".\tools\VERIFICATION.txt" = @{
+      "(?i)(32-Bit.+)\<.*\>"     = "`${1}<$($Latest.URL32)>"
     }
   }
 }


### PR DESCRIPTION
Move Github Desktop to include the installer in the package.

The AU script is working, and the package is installing fine. 

Also, the `/nolaunch`  switch seems to be broken, as it is launching after install, but I can't find a switch to fix it.