### PR TITLE
Element desktop improvement

### DIFF
--- a/automatic/element-desktop/tools/chocolateyInstall.ps1
+++ b/automatic/element-desktop/tools/chocolateyInstall.ps1
@@ -1,9 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir              = Split-Path $MyInvocation.MyCommand.Definition
-$file64                = (Get-Childitem -Path $toolsDir -Filter "*_x64.exe").fullname
 
 $packageArgs = @{
-  file64         = $file64
+  file64         = Join-Path $toolsDir 'Element%20Setup%201.7.25_x64.exe'
   packageName    = $env:ChocolateyPackageName
   installerType  = 'exe'
   silentArgs     = '--silent'
@@ -13,4 +12,4 @@ $packageArgs = @{
 
 Install-ChocolateyInstallPackage @packageArgs
 
-Remove-Item -ea 0 -Force $file64 
+Remove-Item -ea 0 -Force -Path $toolsDir\*.exe

--- a/automatic/element-desktop/update.ps1
+++ b/automatic/element-desktop/update.ps1
@@ -9,6 +9,9 @@ function global:au_SearchReplace {
 		  "(?i)(checksum type:).*"   = "`${1} $($Latest.ChecksumType64)"
 		  "(?i)(checksum64:).*"      = "`${1} $($Latest.Checksum64)"
 		}
+        ".\tools\chocolateyinstall.ps1" = @{
+            "(?i)(^\s*File64\s*=\s*)(.*)" = "`$1Join-Path `$toolsDir '$($Latest.FileName64)'"
+        }
     }
 }
 


### PR DESCRIPTION
This makes element-desktop use an explicit filename, instead of using `get-childitem`. 
It also removes all .exe files from the tools directory, not just the `.exe` for the current version.

Using `Get-Childitem` can fail on upgrade if the previous `.exe` was not removed for some reason.
