### PR TITLE
update url

### DIFF
--- a/gamingapp/tools/chocolateyInstall.ps1
+++ b/gamingapp/tools/chocolateyInstall.ps1
@@ -2,11 +2,11 @@
 
 $packageName    = 'gamingapp' 
 $installerType  = 'exe' 
-$url            = 'http://download.msi.com/uti_exe/gaming_app_6.zip' 
+$url            = 'http://download.msi.com/uti_exe/vga/gaming_app_6.zip' 
 $silentArgs     = '/VERYSILENT' 
 $validExitCodes = @(0) 
 $scriptDir      = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$exe            = "$scriptDir\6.2.0.97\Gaming APP.exe"
+$exe            = "$scriptDir\6.2.0.98\Gaming APP.exe"
 
-Install-ChocolateyZipPackage "$packageName" "$url" "$scriptDir" -Checksum 9269DE9880CF2B98B7100E8CDC42F3A6F4A42FD5E2856B91045E296DA9B698E5 -ChecksumType sha256
+Install-ChocolateyZipPackage "$packageName" "$url" "$scriptDir" -Checksum D028B8EA913F6A99F62E96F947E6DC223609FBF345E46ED51C0FB19C87EA08EB -ChecksumType sha256
 Install-ChocolateyInstallPackage "$packageName" "$installerType" "$silentArgs" "$exe"


### PR DESCRIPTION
It seems like the URL has changed (I got to this new one from [here](https://www.msi.com/Graphics-Card/support/GTX-970-GAMING-4G-LE#down-driver&Win10%2064)).
The version number seems to have been incremented as well which means the exe dir has changed.
I have also updated the checksum of the remote zip.