### PR TITLE
(github-desktop) AU - updated for cleaner download URL detection 

### DIFF
--- a/automatic/github-desktop/github-desktop.nuspec
+++ b/automatic/github-desktop/github-desktop.nuspec
@@ -6,7 +6,7 @@
     <version>2.9.0</version>
     <packageSourceUrl>https://github.com/TakataSanshiro/Chocolatey-Packages/tree/master/automatic/github-desktop</packageSourceUrl>
     <authors>GitHub</authors>
-    <owners>Sanshiro</owners>
+    <owners>Sanshiro virtualex</owners>
     <summary>The new native. Extend your GitHub workflow beyond your browser with our Desktop Beta, completely redesigned with Electron. Get a unified cross-platform experience that’s completely open source and ready to customize.</summary>
     <description>
 ## This essentially replaces https://chocolatey.org/packages/GitHub but is a different application.

--- a/automatic/github-desktop/tools/VERIFICATION.txt
+++ b/automatic/github-desktop/tools/VERIFICATION.txt
@@ -3,7 +3,7 @@ Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
  
 1. Download release from 
-    32-Bit: <https://desktop.githubusercontent.com/releases/2.9.0-4806a6dc/GitHubDesktopSetup-x64.exe>
+    64-Bit: <https://desktop.githubusercontent.com/releases/2.9.0-4806a6dc/GitHubDesktopSetup-x64.exe>
 
 2. Get sha256 checksum with utility of choice
 

--- a/automatic/github-desktop/update.ps1
+++ b/automatic/github-desktop/update.ps1
@@ -9,7 +9,7 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\tools\VERIFICATION.txt" = @{
-      "(?i)(32-Bit.+)\<.*\>"     = "`${1}<$($Latest.URL32)>"
+      "(?i)(64-Bit.+)\<.*\>"     = "`${1}<$($Latest.URL64)>"
     }
   }
 }
@@ -18,14 +18,12 @@ function global:au_GetLatest {
   $response = Invoke-WebRequest -Uri $releases -UseBasicParsing
   
   $re = 'win32'
-  $Url32 = Get-RedirectedUrl ($response.Links | Where-Object { $_.href -match $re } | Select-Object -First 1 -ExpandProperty href)
-  
-  $chlog = 'https://central.github.com/deployments/desktop/desktop/changelog.json'
-  $version = (Invoke-WebRequest -Uri $chlog | ConvertFrom-Json).version[0]
+  $Url64 = Get-RedirectedUrl ($response.Links | Where-Object { $_.href -match $re } | Select-Object -First 1 -ExpandProperty href)
+  $version = (($Url64).Split('/|-') | Where-Object { $_ -match '(\d+)' })[0]
 
   return @{
     Version = $version
-    URL32   = $Url32
+    URL64   = $Url64
   }
 }
 


### PR DESCRIPTION
Modified package ` update.ps1` for a cleaner way of detecting the download file URL as current published package is out-of-date, and changed `Verification.txt` to reflect proper `64-Bit` instead of `32-Bit`.

Also added myself so an owner in the `.nuspec`, please add me as a co-maintainer - username: `virtualex`.

Fully tested in my AU testing environment as well as `chocolatey-test-environment`.